### PR TITLE
Add Brew and Nix Flakes package support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
-      - name: Start Cassandra with docker-compose
+      - name: Start Cassandra with docker compose
         run: |
-          docker-compose -f docker-compose.test.yml up -d cassandra
+          docker compose -f docker-compose.test.yml up -d cassandra
           echo "Waiting for Cassandra to be healthy..."
-          timeout 300 bash -c 'until docker-compose -f docker-compose.test.yml ps | grep cassandra | grep -q "healthy"; do sleep 5; done'
+          timeout 300 bash -c 'until docker compose -f docker-compose.test.yml ps | grep cassandra | grep -q "healthy"; do sleep 5; done'
           echo "Cassandra is ready!"
 
       - name: Run tests
@@ -39,7 +39,7 @@ jobs:
 
       - name: Stop Cassandra
         if: always()
-        run: docker-compose -f docker-compose.test.yml down -v
+        run: docker compose -f docker-compose.test.yml down -v
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,22 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      - name: Start Cassandra with docker-compose
+        run: |
+          docker-compose -f docker-compose.test.yml up -d cassandra
+          echo "Waiting for Cassandra to be healthy..."
+          timeout 300 bash -c 'until docker-compose -f docker-compose.test.yml ps | grep cassandra | grep -q "healthy"; do sleep 5; done'
+          echo "Cassandra is ready!"
+
       - name: Run tests
+        env:
+          CASSANDRA_HOST: 127.0.0.1
+          CASSANDRA_PORT: 9042
         run: go test -v -race -coverprofile=coverage.out ./...
+
+      - name: Stop Cassandra
+        if: always()
+        run: docker-compose -f docker-compose.test.yml down -v
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ dist/
 # Test coverage
 coverage.out
 coverage.html
+
+# Nix
+result
+result-*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,6 +89,20 @@ changelog:
     - title: Other
       order: 999
 
+brews:
+  - repository:
+      owner: npenkov
+      name: gcqlsh
+      branch: main
+    folder: Formula
+    homepage: "https://github.com/npenkov/gcqlsh"
+    description: "Cassandra command line shell written in Go"
+    license: "MIT"
+    test: |
+      system "#{bin}/gcqlsh -v"
+    install: |
+      bin.install "gcqlsh"
+
 release:
   # Repo name is extracted from git remote
   github:
@@ -110,6 +124,19 @@ release:
     ### Download Binary
 
     Download the appropriate binary for your platform from the assets above.
+
+    ### Using Homebrew (macOS/Linux)
+
+    ```bash
+    brew tap npenkov/gcqlsh
+    brew install gcqlsh
+    ```
+
+    ### Using Nix Flakes
+
+    ```bash
+    nix profile install github:npenkov/gcqlsh
+    ```
 
     ### Using Go
 

--- a/Formula/gcqlsh.rb
+++ b/Formula/gcqlsh.rb
@@ -1,0 +1,39 @@
+class Gcqlsh < Formula
+  desc "Cassandra command line shell written in Go"
+  homepage "https://github.com/npenkov/gcqlsh"
+  version "0.0.3"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/npenkov/gcqlsh/releases/download/v#{version}/gcqlsh_darwin_arm64.tar.gz"
+      sha256 "" # Will be updated automatically by goreleaser
+    else
+      url "https://github.com/npenkov/gcqlsh/releases/download/v#{version}/gcqlsh_darwin_x86_64.tar.gz"
+      sha256 "" # Will be updated automatically by goreleaser
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      if Hardware::CPU.is_64_bit?
+        url "https://github.com/npenkov/gcqlsh/releases/download/v#{version}/gcqlsh_linux_arm64.tar.gz"
+        sha256 "" # Will be updated automatically by goreleaser
+      else
+        url "https://github.com/npenkov/gcqlsh/releases/download/v#{version}/gcqlsh_linux_armv7.tar.gz"
+        sha256 "" # Will be updated automatically by goreleaser
+      end
+    else
+      url "https://github.com/npenkov/gcqlsh/releases/download/v#{version}/gcqlsh_linux_x86_64.tar.gz"
+      sha256 "" # Will be updated automatically by goreleaser
+    end
+  end
+
+  def install
+    bin.install "gcqlsh"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gcqlsh -v")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -14,6 +14,69 @@ Having a cassandra command line shell utility in one binary distributable.
 - Running cql shell on all platforms.
 - Automating cassandra schema creation without need to install python dependencies.
 
+## Installation
+
+### Using Homebrew (macOS/Linux)
+
+```bash
+brew tap npenkov/gcqlsh
+brew install gcqlsh
+```
+
+Or install directly from the repository:
+
+```bash
+brew install npenkov/gcqlsh/gcqlsh
+```
+
+### Using Nix Flakes
+
+#### Direct run without installation
+
+```bash
+nix run github:npenkov/gcqlsh
+```
+
+#### Install to user profile
+
+```bash
+nix profile install github:npenkov/gcqlsh
+```
+
+#### Add to NixOS configuration or Home Manager
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    gcqlsh.url = "github:npenkov/gcqlsh";
+  };
+
+  outputs = { self, nixpkgs, gcqlsh }: {
+    # ... your configuration
+    environment.systemPackages = [
+      gcqlsh.packages.${system}.default
+    ];
+  };
+}
+```
+
+#### Development shell
+
+```bash
+nix develop github:npenkov/gcqlsh
+```
+
+### Using Go
+
+```bash
+go install github.com/npenkov/gcqlsh/cmd/gcqlsh@latest
+```
+
+### Download Binary
+
+Download the latest release binary for your platform from the [releases page](https://github.com/npenkov/gcqlsh/releases).
+
 ## Building
 
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "Cassandra command line shell written in Go";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        version = builtins.readFile ./VERSION;
+        trimmedVersion = builtins.replaceStrings [ "\n" ] [ "" ] version;
+      in
+      {
+        packages = {
+          default = pkgs.buildGoModule {
+            pname = "gcqlsh";
+            version = trimmedVersion;
+
+            src = ./.;
+
+            vendorHash = "sha256-LBD3E+IvOALSrSF5RqYE6pW/QHJJ9TfSBYnWKGU3aSk=";
+
+            # Main package path
+            subPackages = [ "cmd/gcqlsh" ];
+
+            ldflags = [
+              "-s"
+              "-w"
+              "-X main.version=${trimmedVersion}"
+            ];
+
+            meta = with pkgs.lib; {
+              description = "Cassandra command line shell written in Go";
+              homepage = "https://github.com/npenkov/gcqlsh";
+              license = licenses.mit;
+              maintainers = [ ];
+              mainProgram = "gcqlsh";
+            };
+          };
+
+          gcqlsh = self.packages.${system}.default;
+        };
+
+        apps = {
+          default = flake-utils.lib.mkApp {
+            drv = self.packages.${system}.default;
+          };
+
+          gcqlsh = self.apps.${system}.default;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go
+            gopls
+            gotools
+            go-tools
+            goreleaser
+          ];
+
+          shellHook = ''
+            echo "gcqlsh development environment"
+            echo "Go version: $(go version)"
+          '';
+        };
+      });
+}

--- a/internal/action/cql_test.go
+++ b/internal/action/cql_test.go
@@ -97,7 +97,7 @@ func TestProcessCommand_UseKeyspace(t *testing.T) {
 	}
 
 	// Switch back to test_keyspace
-	ProcessCommand("USE test_keyspace", testSession)
+	_, _, _ = ProcessCommand("USE test_keyspace", testSession)
 	if testSession.ActiveKeyspace != "test_keyspace" {
 		t.Errorf("Expected active keyspace to be 'test_keyspace', got: %s", testSession.ActiveKeyspace)
 	}
@@ -130,7 +130,7 @@ func TestProcessCommand_UseKeyspaceUppercase(t *testing.T) {
 	}
 
 	// Switch back to test_keyspace
-	ProcessCommand("use test_keyspace;", testSession)
+	_, _, _ = ProcessCommand("use test_keyspace;", testSession)
 }
 
 func TestProcessCommand_DescribeKeyspaces(t *testing.T) {

--- a/internal/action/list.go
+++ b/internal/action/list.go
@@ -27,7 +27,7 @@ func ListColumns(cks *db.CQLKeyspaceSession, prefix string) func(string) []strin
 		tableName = strings.Fields(tableName)[0]
 		columns, _ := cks.FetchColumns(tableName)
 		cols := make([]string, 0)
-		for col, _ := range columns {
+		for col := range columns {
 			cols = append(cols, col)
 		}
 		return cols

--- a/internal/action/tracer_test.go
+++ b/internal/action/tracer_test.go
@@ -37,7 +37,7 @@ func TestNewTracer(t *testing.T) {
 
 			tracer := NewTracer(testSession)
 			if tracer == nil {
-				t.Error("Expected tracer to be non-nil")
+				t.Fatal("Expected tracer to be non-nil")
 			}
 
 			if tracer.cks == nil {

--- a/internal/runtime/interactive.go
+++ b/internal/runtime/interactive.go
@@ -118,7 +118,7 @@ func RunInteractiveSession(cks *db.CQLKeyspaceSession) error {
 			break
 		}
 		rl.SetPrompt(fmt.Sprintf("%s:%s> ", ProgramPromptPrefix, cks.ActiveKeyspace))
-		rl.SaveHistory(cmd)
+		_ = rl.SaveHistory(cmd)
 	}
 	return nil
 }


### PR DESCRIPTION
- Add Homebrew formula in Formula/gcqlsh.rb for tap installation
- Configure GoReleaser to auto-update Homebrew formula on releases
- Add Nix flake.nix for declarative package management
- Update README with comprehensive installation instructions:
  - Homebrew installation via tap
  - Nix flakes installation and configuration examples
  - Go install method
  - Binary download option
- Update .gitignore to exclude Nix build artifacts (result symlinks)
- Update GoReleaser release notes template with new installation methods