### PR TITLE
Fix CI/CD release pipeline Cassandra connection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,25 @@ jobs:
           go-version: '1.24'
           cache: true
 
-      - name: Run tests
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Start Cassandra with docker compose
         run: |
-          go mod download
-          go test -v ./...
+          docker compose -f docker-compose.test.yml up -d cassandra
+          echo "Waiting for Cassandra to be healthy..."
+          timeout 300 bash -c 'until docker compose -f docker-compose.test.yml ps | grep cassandra | grep -q "healthy"; do sleep 5; done'
+          echo "Cassandra is ready!"
+
+      - name: Run tests
+        env:
+          CASSANDRA_HOST: 127.0.0.1
+          CASSANDRA_PORT: 9042
+        run: go test -v ./...
+
+      - name: Stop Cassandra
+        if: always()
+        run: docker compose -f docker-compose.test.yml down -v
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
The release workflow was failing because integration tests require a running Cassandra instance. Added docker-compose setup to:
- Start Cassandra with docker compose before tests
- Wait for Cassandra to be healthy
- Set CASSANDRA_HOST and CASSANDRA_PORT environment variables
- Clean up Cassandra after tests (even on failure)

This matches the approach used in the test.yml workflow that runs successfully on regular CI builds.